### PR TITLE
[Hotfix: 404 error after page refresh] closes issue #22

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -25,7 +25,7 @@ app.use('/api/members', membersRoute);
 app.use('/api/elections', electionsRoute);
 
 app.get('/*', function(req, res) {
-  res.sendFile(path.join(__dirname, '../client/public/index.html'), function(err) {
+  res.sendFile(path.join(__dirname, '../client/build/index.html'), function(err) {
     if (err) {
       res.status(500).send(err)
     }


### PR DESCRIPTION
**Problem:**

> React Router is handling the routing logic.
> But React Router can only load after the first successful GET request to server.
> 
> Everytime we refresh /quemsomos page, we first send a request GET "/quemsomos"  REQUEST to our server and this is failing because we have no logic on our server side for handling this request since this was suppose to be handled by React Router.

**Solution:**

> Redirect all the requests to index.html.
> We load the index.html, fetch any resources we need, React Router then takes over and loads the appropriate view.