### PR TITLE
[HOTFIX] Corrected the SINFO URL

### DIFF
--- a/client/src/pages/SubgroupsPage.jsx
+++ b/client/src/pages/SubgroupsPage.jsx
@@ -36,7 +36,7 @@ const SubgroupsPage = () => (
 
     <div style={{ margin: '1rem 20vw 2rem 20vw', textAlign: 'center' }}>
       <Button
-        href="https://www.facebook.com/NEIIST/events/"
+        href="https://www.sinfo.org"
         target="_blank"
         rel="noreferrer"
       >


### PR DESCRIPTION
Changed the old URL associated with SINFO to the correct one.
https://www.facebook.com/NEIIST/events/ -> https://www.sinfo.org