### PR TITLE
feat(homepage): conditionally render monetary partners section

### DIFF
--- a/src/components/homepage/Partnerships.tsx
+++ b/src/components/homepage/Partnerships.tsx
@@ -64,11 +64,17 @@ const Partnerships: React.FC = () => {
       </a>
     ));
 
+  const showMonetaryPartners = false;
+
   return (
     <div className={styles.partnerships}>
       <h1 className={styles.title}>Parcerias</h1>
-      <h2>Parcerias Monetárias</h2>
-      <div className={styles.row}>{renderPartners(monetaryPartners)}</div>
+      {showMonetaryPartners && (
+        <>
+          <h2>Parcerias Monetárias</h2>
+          <div className={styles.row}>{renderPartners(monetaryPartners)}</div>
+        </>
+      )}
       <h2>Parcerias Não Monetárias</h2>
       <div className={styles.row}>{renderPartners(nonMonetaryPartners)}</div>
     </div>


### PR DESCRIPTION
## Description

Implemented conditional rendering for monetary partners section to hidden or removed from rendering. 

---

## Screenshots

Before
<img width="1772" height="982" alt="Screenshot 2025-10-19 at 10 13 42 PM" src="https://github.com/user-attachments/assets/74c69253-7a94-4309-a971-63f63a7cef66" />

After:
<img width="1772" height="987" alt="Screenshot 2025-10-19 at 10 09 19 PM" src="https://github.com/user-attachments/assets/34672480-36bc-493a-be4b-5ca57d1250b5" />

---

resolves #588 