### PR TITLE
fix: ignoring python venv and ensuring init script is run with bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,12 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
+# Data
+data/
+
 # Environment Variables
 .env
+.venv
 
 # TypeScript
 *.tsbuildinfo

--- a/config/prettier/.prettierignore
+++ b/config/prettier/.prettierignore
@@ -16,4 +16,4 @@ yarn.lock
 package-lock.json
 .vscode/
 .idea/
-
+.venv/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e  # Exit immediately if a command exits with a non-zero status
 
 echo "NEIIST Dev Env Setup Script"


### PR DESCRIPTION
## Description

Added .venv/ to the list of files/folders to ignore in both .gitignore and .prettierignore.
Added bash shebang to setup script to avoid sh incompatibility.