### PR TITLE
feat(security): add rate limiting and CSP headers (#646)

### DIFF
--- a/src/lib/rateLimitRules.ts
+++ b/src/lib/rateLimitRules.ts
@@ -1,0 +1,26 @@
+export interface RateLimitRule {
+  limit: number;
+  windowMs: number;
+  useUser?: boolean;
+}
+
+const MIN = 60_000;
+
+export function getRateLimitRule(pathname: string): RateLimitRule | null {
+  if (pathname === "/api/auth/login" || pathname === "/api/auth/callback") {
+    return { limit: 5, windowMs: 15 * MIN };
+  }
+  if (pathname === "/api/auth/refresh") {
+    return { limit: 10, windowMs: MIN };
+  }
+  if (pathname.startsWith("/api/user/verify-email/")) {
+    return { limit: 3, windowMs: 15 * MIN };
+  }
+  if (pathname.startsWith("/api/admin/")) {
+    return { limit: 30, windowMs: MIN, useUser: true };
+  }
+  if (pathname.startsWith("/api/")) {
+    return { limit: 60, windowMs: MIN };
+  }
+  return null;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { UserRole } from "@/types/user";
 import { hasRequiredRole } from "@/types/user";
 import { getUserFromJWT } from "./utils/authUtils";
+import { rateLimit } from "@/utils/security/rateLimitUtils";
+import { CSP } from "@/utils/security/cspUtils";
 
 const publicRoutes = ["/home", "/about-us", "/email-confirmation", "/shop", "/activities"];
 const guestRoutes = ["/profile", "/my-orders", "/shop/cart", "/shop/checkout"];
@@ -9,6 +11,52 @@ const memberRoutes = ["/orders"];
 const coordRoutes = ["/team-management", "/photo-management"];
 const adminRoutes = ["/users-management", "/departments-management", "/shop/manage"];
 const protectedRoutes = [guestRoutes, memberRoutes, coordRoutes, adminRoutes].flat();
+
+interface RateLimitRule {
+  limit: number;
+  windowMs: number;
+  useUser?: boolean;
+}
+
+function getRateLimitRule(pathname: string): RateLimitRule | null {
+  if (pathname === "/api/auth/login" || pathname === "/api/auth/callback") {
+    return { limit: 5, windowMs: 15 * 60_000 };
+  }
+  if (pathname === "/api/auth/refresh") {
+    return { limit: 10, windowMs: 60_000 };
+  }
+  if (pathname.startsWith("/api/user/verify-email/")) {
+    return { limit: 3, windowMs: 15 * 60_000 };
+  }
+  if (pathname.startsWith("/api/admin/")) {
+    return { limit: 30, windowMs: 60_000, useUser: true };
+  }
+  if (pathname.startsWith("/api/")) {
+    return { limit: 60, windowMs: 60_000 };
+  }
+  return null;
+}
+
+function getIp(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+const isDev = process.env.NODE_ENV === "development";
+
+function addSecurityHeaders(response: NextResponse) {
+  response.headers.set("Content-Security-Policy", CSP);
+  response.headers.set("X-Frame-Options", "DENY");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  if (!isDev) {
+    response.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  }
+}
 
 function canAccess(path: string, roles: UserRole[]) {
   if (path === "/" || publicRoutes.slice(1).some((r) => path.startsWith(r))) return true;
@@ -43,14 +91,48 @@ function canAccess(path: string, roles: UserRole[]) {
 
 export function proxy(req: NextRequest) {
   const path = req.nextUrl.pathname;
+
+  if (path.startsWith("/api/")) {
+    const rule = getRateLimitRule(path);
+    if (rule) {
+      const sessionToken = req.cookies.get("session")?.value;
+      const jwtUser = getUserFromJWT(sessionToken);
+      const identifier = rule.useUser ? (jwtUser?.istid ?? getIp(req)) : getIp(req);
+      const bucketKey = `${path.split("/").slice(0, 4).join("/")}:${identifier}`;
+      const result = rateLimit(bucketKey, rule.limit, rule.windowMs);
+
+      if (!result.success) {
+        const retryAfter = Math.ceil((result.reset - Date.now()) / 1000);
+        return new NextResponse(JSON.stringify({ error: "Too many requests" }), {
+          status: 429,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": String(retryAfter),
+            "X-RateLimit-Limit": String(rule.limit),
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": String(result.reset),
+          },
+        });
+      }
+    }
+
+    const response = NextResponse.next();
+    addSecurityHeaders(response);
+    return response;
+  }
+
   const accessToken = req.cookies.get("access_token")?.value;
   const isAuthenticated = !!accessToken;
 
   if (!isAuthenticated && protectedRoutes.some((r) => path.startsWith(r))) {
     if (path !== "/api/auth/login") {
-      return NextResponse.redirect(new URL("/api/auth/login", req.url));
+      const response = NextResponse.redirect(new URL("/api/auth/login", req.url));
+      addSecurityHeaders(response);
+      return response;
     }
-    return NextResponse.next();
+    const response = NextResponse.next();
+    addSecurityHeaders(response);
+    return response;
   }
 
   if (isAuthenticated) {
@@ -60,15 +142,21 @@ export function proxy(req: NextRequest) {
 
     if (!canAccess(path, roles)) {
       if (path !== "/unauthorized") {
-        return NextResponse.redirect(new URL("/unauthorized", req.url));
+        const response = NextResponse.redirect(new URL("/unauthorized", req.url));
+        addSecurityHeaders(response);
+        return response;
       }
-      return NextResponse.next();
+      const response = NextResponse.next();
+      addSecurityHeaders(response);
+      return response;
     }
   }
 
-  return NextResponse.next();
+  const response = NextResponse.next();
+  addSecurityHeaders(response);
+  return response;
 }
 
 export const config = {
-  matcher: ["/((?!api|_next/|favicon\\.ico|products/|static/|images/|image/|.*\\..*$).*)"],
+  matcher: ["/((?!_next/|favicon\\.ico|products/|static/|images/|image/|.*\\..*$).*)"],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,7 @@ import { hasRequiredRole } from "@/types/user";
 import { getUserFromJWT } from "./utils/authUtils";
 import { rateLimit } from "@/utils/security/rateLimitUtils";
 import { CSP } from "@/utils/security/cspUtils";
+import { getRateLimitRule } from "@/lib/rateLimitRules";
 
 const publicRoutes = ["/home", "/about-us", "/email-confirmation", "/shop", "/activities"];
 const guestRoutes = ["/profile", "/my-orders", "/shop/cart", "/shop/checkout"];
@@ -11,31 +12,6 @@ const memberRoutes = ["/orders"];
 const coordRoutes = ["/team-management", "/photo-management"];
 const adminRoutes = ["/users-management", "/departments-management", "/shop/manage"];
 const protectedRoutes = [guestRoutes, memberRoutes, coordRoutes, adminRoutes].flat();
-
-interface RateLimitRule {
-  limit: number;
-  windowMs: number;
-  useUser?: boolean;
-}
-
-function getRateLimitRule(pathname: string): RateLimitRule | null {
-  if (pathname === "/api/auth/login" || pathname === "/api/auth/callback") {
-    return { limit: 5, windowMs: 15 * 60_000 };
-  }
-  if (pathname === "/api/auth/refresh") {
-    return { limit: 10, windowMs: 60_000 };
-  }
-  if (pathname.startsWith("/api/user/verify-email/")) {
-    return { limit: 3, windowMs: 15 * 60_000 };
-  }
-  if (pathname.startsWith("/api/admin/")) {
-    return { limit: 30, windowMs: 60_000, useUser: true };
-  }
-  if (pathname.startsWith("/api/")) {
-    return { limit: 60, windowMs: 60_000 };
-  }
-  return null;
-}
 
 function getIp(request: NextRequest): string {
   return (

--- a/src/utils/security/cspUtils.ts
+++ b/src/utils/security/cspUtils.ts
@@ -1,0 +1,21 @@
+const isDev = process.env.NODE_ENV === "development";
+
+const directives: Record<string, string[]> = {
+  "default-src": ["'self'"],
+  "script-src": ["'self'", "'unsafe-inline'", ...(isDev ? ["'unsafe-eval'"] : [])],
+  "style-src": ["'self'", "'unsafe-inline'"],
+  "font-src": ["'self'"],
+  // TODO: add Cloudflare R2/CDN domain to img-src and connect-src when implemented
+  "img-src": ["'self'", "data:", "blob:", "https://neiist.tecnico.ulisboa.pt"],
+  "connect-src": ["'self'", "https://api.sumup.com", "https://gateway.sumup.com"],
+  "frame-src": ["https://gateway.sumup.com"],
+  "object-src": ["'none'"],
+  "base-uri": ["'self'"],
+  "form-action": ["'self'"],
+  "frame-ancestors": ["'none'"],
+  ...(!isDev ? { "upgrade-insecure-requests": [] } : {}),
+};
+
+export const CSP = Object.entries(directives)
+  .map(([key, values]) => (values.length ? `${key} ${values.join(" ")}` : key))
+  .join("; ");

--- a/src/utils/security/rateLimitUtils.ts
+++ b/src/utils/security/rateLimitUtils.ts
@@ -1,0 +1,37 @@
+interface RateLimitResult {
+  success: boolean;
+  remaining: number;
+  reset: number;
+}
+
+const store = new Map<string, number[]>();
+
+const CLEANUP_THRESHOLD = 5000;
+const STALE_AFTER_MS = 60 * 60 * 1000;
+
+function maybeCleanup(now: number) {
+  if (store.size < CLEANUP_THRESHOLD) return;
+  for (const [key, timestamps] of store.entries()) {
+    if (timestamps.length === 0 || now - timestamps[timestamps.length - 1] > STALE_AFTER_MS) {
+      store.delete(key);
+    }
+  }
+}
+
+export function rateLimit(identifier: string, limit: number, windowMs: number): RateLimitResult {
+  const now = Date.now();
+  const windowStart = now - windowMs;
+
+  maybeCleanup(now);
+
+  const timestamps = (store.get(identifier) ?? []).filter((t) => t > windowStart);
+
+  if (timestamps.length >= limit) {
+    return { success: false, remaining: 0, reset: timestamps[0] + windowMs };
+  }
+
+  timestamps.push(now);
+  store.set(identifier, timestamps);
+
+  return { success: true, remaining: limit - timestamps.length, reset: timestamps[0] + windowMs };
+}


### PR DESCRIPTION
## Description

Implements API rate limiting and Content Security Policy (CSP) headers to protect the application from abuse and control resource loading in the browser.

Fixes #646

**Rate limiting** is applied per IP (and per user for admin routes) using an in-memory sliding-window algorithm:
- `/api/auth/login`, `/api/auth/callback` — 5 req / 15 min
- `/api/auth/refresh` — 10 req / min
- `/api/user/verify-email/*` — 3 req / 15 min
- `/api/admin/*` — 30 req / min (identified by IST ID)
- All other `/api/*` — 60 req / min

**CSP headers** are applied to all HTTP responses (pages + API) and cover SumUp, Google Fonts (self-hosted via `next/font`), and include a placeholder for Cloudflare R2/CDN.

Additional security headers added: `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Strict-Transport-Security` (production only).